### PR TITLE
fixing run synchronizedbeforesuite

### DIFF
--- a/test/utils/client/clients.go
+++ b/test/utils/client/clients.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Client defines the client set that will be used for testing
-var Client = &ClientSet{}
+var Client *ClientSet
 
 // ClientSet provides the struct to talk with relevant API
 type ClientSet struct {


### PR DESCRIPTION
Fixing Synchronized before suite so that config init code is run only once. 
Clientset init is still ran once per test