### PR TITLE
test: restore hard failures for discovery, HA, and holdover asserts

### DIFF
--- a/test/conformance/parallel/parallel_suite_test.go
+++ b/test/conformance/parallel/parallel_suite_test.go
@@ -81,12 +81,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			fullConfig = testconfig.GetFullDiscoveredConfig(pkg.PtpLinuxDaemonNamespace, true)
 		})
 	}
-	if fullConfig.Status != testconfig.DiscoverySuccessStatus {
-		Skip("parallel suite requires successful PTP discovery")
-	}
-	if fullConfig.DiscoveredClockUnderTestPod == nil {
-		Skip("clock-under-test pod missing; label node with " + pkg.PtpClockUnderTestNodeLabel)
-	}
+	Expect(fullConfig.Status).To(Equal(testconfig.DiscoverySuccessStatus), "parallel suite requires successful PTP discovery")
+	Expect(fullConfig.DiscoveredClockUnderTestPod).NotTo(BeNil(),
+		"clock-under-test pod missing; label node with "+pkg.PtpClockUnderTestNodeLabel)
 	// Avoid RestartPTPDaemon when reusing serial configs: a daemon bounce mid-serial
 	// races the same way as clean.All. Only restart after we created configs.
 	if !reusedSerialConfigs {

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -325,9 +325,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			}
 			ptpOperatorConfig.Spec.EventConfig.EnableEventPublisher = true
 			_, err = client.Client.PtpV1Interface.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Update(context.Background(), ptpOperatorConfig, metav1.UpdateOptions{})
-			if err != nil && kerrors.IsInternalError(err) && strings.Contains(err.Error(), "webhook") {
-				Skip("Skipping: PtpOperatorConfig admission webhook is not available in this environment")
-			}
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Reading back and verifying EnableEventPublisher is true")
@@ -381,7 +378,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 - the ptpconfig has a %s label only in the recommend section (no node section)
 - the node running the clock under test is label with: %s`, pkg.PtpClockUnderTestNodeLabel, pkg.PtpClockUnderTestNodeLabel)
 
-				Skip("Failed to find a valid ptp slave configuration")
+				Fail("Failed to find a valid ptp slave configuration")
 
 			}
 			if fullConfig.PtpModeDesired != testconfig.Discovery {
@@ -1128,8 +1125,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				//  1) SinceTime from before slave wait (fresh selection during start)
 				//  2) large TailLines (aged selection still current)
 				//  3) if still none and exactly one primary slave: use that iface
-				//     (HA prefers the healthy primary profile; fail closed if HA
-				//     was already on secondary — failover Eventually will timeout)
 				var selectedInterface string
 				var logMatches [][]string
 
@@ -1174,65 +1169,64 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				}
 				primaryInterface := selectedInterface
 
+				// Wait so the regex won't match the previous log entry
+				time.Sleep(2 * time.Second)
 				ifDownTime := time.Now()
 				By("Taking down the selected interface " + selectedInterface)
 				nodeName := fullConfig.DiscoveredClockUnderTestPod.Spec.NodeName
 				portEngine.TurnOffAndWaitFaulty(selectedInterface, nodeName)
 
-				By("Waiting for phc2sys to fail over to a secondary BC slave")
-				var newSelectedInterface string
-				Eventually(func() error {
-					matches, err := pods.GetPodLogsRegexSince(fullConfig.DiscoveredClockUnderTestPod.Namespace,
-						fullConfig.DiscoveredClockUnderTestPod.Name, pkg.PtpContainerName,
-						phc2sysLogPattern, false, 10*time.Second, ifDownTime)
-					if err != nil {
-						return err
-					}
-					if ptptesthelper.CountPhc2sysTransitions(matches, selectedInterface) != 1 {
-						return fmt.Errorf("want exactly 1 primary->secondary transition; got %d sequence=%v",
-							ptptesthelper.CountPhc2sysTransitions(matches, selectedInterface),
-							ptptesthelper.Phc2sysMatchedInterfaces(matches))
-					}
-					iface := matches[len(matches)-1][1]
-					if !slices.Contains(secondaryBCSlaveInterfaces, iface) {
-						return fmt.Errorf("post-failover HA source %s not in secondary BC slaves %v",
-							iface, secondaryBCSlaveInterfaces)
-					}
-					newSelectedInterface = iface
-					logMatches = matches
-					return nil
-				}, pkg.TimeoutIn1Minute, 2*time.Second).Should(Succeed())
-				logrus.Infof("phc2sys HA source (secondary): %s; last line: %v", newSelectedInterface, logMatches[len(logMatches)-1][0])
+				By("Waiting for 5 seconds for the new interface to be selected")
+				time.Sleep(5 * time.Second)
 
+				By("Verifying phc2sys switches to a different interface")
+				var newSelectedInterface string
+				var err error
+				logMatches, err = pods.GetPodLogsRegexSince(fullConfig.DiscoveredClockUnderTestPod.Namespace,
+					fullConfig.DiscoveredClockUnderTestPod.Name, pkg.PtpContainerName,
+					phc2sysLogPattern, false, pkg.TimeoutIn1Minute, ifDownTime)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(logMatches)).To(BeNumerically(">=", 1), "Could not identify which interface phc2sys switched to after primary interface failed")
+				Expect(ptptesthelper.CountPhc2sysTransitions(logMatches, selectedInterface)).To(Equal(1),
+					fmt.Sprintf("phc2sys should have made exactly 1 transition (primary->secondary) after primary failed; port may be flapping. Sequence: %v",
+						ptptesthelper.Phc2sysMatchedInterfaces(logMatches)))
+				logrus.Infof("phc2sys log matching line: %v", logMatches[len(logMatches)-1][0])
+				newSelectedInterface = logMatches[len(logMatches)-1][1]
+
+				Expect(newSelectedInterface).ToNot(Equal(selectedInterface), "phc2sys should have switched to a different interface")
+				By("Verifying the new selected interface " + newSelectedInterface + " is a secondary BC's slave interface")
+				if !slices.Contains(secondaryBCSlaveInterfaces, newSelectedInterface) {
+					Fail(fmt.Sprintf("Selected interface %s does not belong to the secondary boundary clock config. Secondary interfaces: %v", newSelectedInterface, secondaryBCSlaveInterfaces))
+				}
+
+				time.Sleep(2 * time.Second)
 				ifUpTime := time.Now()
 				By("Restoring the primary BC's slave interface " + primaryInterface)
 				portEngine.TurnOnAndWaitSlave(primaryInterface, nodeName)
 
-				// On recovery, ptp4l briefly promotes the interface to MASTER before a
-				// better master is found and it transitions to SLAVE. That yields one
-				// phc2sys transition: secondary -> primary. >1 indicates flapping.
-				By("Waiting for phc2sys to return to the original primary BC slave")
-				Eventually(func() error {
-					matches, err := pods.GetPodLogsRegexSince(fullConfig.DiscoveredClockUnderTestPod.Namespace,
-						fullConfig.DiscoveredClockUnderTestPod.Name, pkg.PtpContainerName,
-						phc2sysLogPattern, false, 10*time.Second, ifUpTime)
-					if err != nil {
-						return err
-					}
-					if ptptesthelper.CountPhc2sysTransitions(matches, newSelectedInterface) != 1 {
-						return fmt.Errorf("want exactly 1 secondary->primary transition; got %d sequence=%v",
-							ptptesthelper.CountPhc2sysTransitions(matches, newSelectedInterface),
-							ptptesthelper.Phc2sysMatchedInterfaces(matches))
-					}
-					iface := matches[len(matches)-1][1]
-					if iface != primaryInterface {
-						return fmt.Errorf("recovered HA source %s != original primary %s", iface, primaryInterface)
-					}
-					selectedInterface = iface
-					logMatches = matches
-					return nil
-				}, pkg.TimeoutIn1Minute, 2*time.Second).Should(Succeed())
-				logrus.Infof("phc2sys HA source restored: %s; last line: %v", selectedInterface, logMatches[len(logMatches)-1][0])
+				By("Waiting 5 seconds for the primary BC's slave interface to be selected again")
+				time.Sleep(5 * time.Second)
+
+				// On recovery, ptp4l briefly promotes the interface to MASTER before a better master
+				// is found and it transitions to SLAVE. This causes one phc2sys transition:
+				// secondary (during brief MASTER state) -> primary (on SLAVE transition).
+				// More than one transition indicates flapping (e.g. primary->secondary->primary).
+				logMatches, err = pods.GetPodLogsRegexSince(fullConfig.DiscoveredClockUnderTestPod.Namespace,
+					fullConfig.DiscoveredClockUnderTestPod.Name, pkg.PtpContainerName,
+					phc2sysLogPattern, false, pkg.TimeoutIn1Minute, ifUpTime)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(logMatches)).To(BeNumerically(">=", 1), "Could not identify which interface phc2sys switched to after primary interface recovered")
+				Expect(ptptesthelper.CountPhc2sysTransitions(logMatches, newSelectedInterface)).To(Equal(1),
+					fmt.Sprintf("phc2sys should have made exactly 1 transition (secondary->primary) since primary recovered; "+
+						"0 means phc2sys never switched back, >1 indicates flapping. Sequence: %v",
+						ptptesthelper.Phc2sysMatchedInterfaces(logMatches)))
+				logrus.Infof("phc2sys log matching line: %v", logMatches[len(logMatches)-1][0])
+				selectedInterface = logMatches[len(logMatches)-1][1]
+
+				By("Verifying the selected interface " + selectedInterface + " is the original primary BC's slave interface " + primaryInterface)
+				if selectedInterface != primaryInterface {
+					Fail(fmt.Sprintf("Selected interface %s is not the original primary interface %s", selectedInterface, primaryInterface))
+				}
 			})
 
 			// OCPBUGS-66407 / OCPBUGS-59883: Verify clockClass reported by Event API and
@@ -2876,10 +2870,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					if nodeName != "" {
 						logrus.Info("Deploy consumer app for testing event API v2")
 						err := event.CreateConsumerApp(nodeName)
-						if err != nil {
-							logrus.Errorf("PTP events are not available due to consumer app creation error err=%s", err)
-							Skip("Consumer app setup failed")
-						}
+						Expect(err).ToNot(HaveOccurred(), "Consumer app setup failed")
 
 						// Wait a bit more for the consumer pod to be fully ready
 						logrus.Info("Waiting for consumer pod to be fully ready...")
@@ -3209,10 +3200,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				if nodeName != "" {
 					logrus.Info("Deploy consumer app for simulated T-GM event API v2")
 					err := event.CreateConsumerApp(nodeName)
-					if err != nil {
-						logrus.Errorf("PTP events not available: consumer app err=%s", err)
-						Skip("Consumer app setup failed")
-					}
+					Expect(err).ToNot(HaveOccurred(), "Consumer app setup failed")
 					time.Sleep(10 * time.Second)
 					event.InitPubSub()
 				}
@@ -3345,19 +3333,19 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				}, 5*time.Minute, 2*time.Second).Should(Equal("HOLDOVER"),
 					"Expected GM DPLL to enter HOLDOVER after GNSS signal loss")
 
-				By("waiting for GM clock class to degrade in metrics (confirms DPLL→ptp4l pipeline)")
+				By("waiting for GM clock class to reach CC7 (holdover) in metrics")
 				Eventually(func() bool {
 					buf, _, _ := pods.ExecCommand(client.Client, true, gmPod, pkg.PtpContainerName, []string{"curl", pkg.MetricsEndPoint})
-					return checkClockClassInMetrics(buf.String(), "7") || checkClockClassInMetrics(buf.String(), "248")
+					return checkClockClassInMetrics(buf.String(), "7")
 				}, pkg.TimeoutIn5Minutes, 2*time.Second).Should(BeTrue(),
-					"Expected GM clock class to degrade to CC7/CC248 in Prometheus metrics after DPLL HOLDOVER")
+					"Expected GM clock class to reach CC7 (holdover) in Prometheus metrics after DPLL HOLDOVER")
 
-				By("waiting for BC parent gm.ClockClass to cascade-degrade from Locked (6)")
+				By("waiting for BC parent gm.ClockClass to cascade to CC7 (holdover)")
 				Eventually(func() bool {
 					cc, err := ptptesthelper.GetClockClassViaPMC(fullConfig, "/var/run/ptp4l.0.config")
-					return err == nil && (cc == int(fbprotocol.ClockClass7) || cc == ClockClassFreerun)
+					return err == nil && cc == int(fbprotocol.ClockClass7)
 				}, pkg.TimeoutIn10Minutes, 2*time.Second).Should(BeTrue(),
-					"Expected BC parent gm.ClockClass to cascade-degrade after upstream GM GNSS loss")
+					"Expected BC parent gm.ClockClass to cascade to CC7 after upstream GM GNSS loss")
 
 				By("restoring GNSS signal via gnss-sim API")
 				simErr = ptphelper.GNSSSimSignalRestore()
@@ -3416,10 +3404,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				if nodeName != "" {
 					logrus.Info("Deploy consumer app for TGMBC event API v2")
 					err := event.CreateConsumerApp(nodeName)
-					if err != nil {
-						logrus.Errorf("PTP events not available: consumer app err=%s", err)
-						Skip("Consumer app setup failed")
-					}
+					Expect(err).ToNot(HaveOccurred(), "Consumer app setup failed")
 					time.Sleep(10 * time.Second)
 					event.InitPubSub()
 				}
@@ -3477,9 +3462,9 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				By("Waiting for GM clock class to degrade in metrics before collecting events")
 				Eventually(func() bool {
 					buf, _, _ := pods.ExecCommand(client.Client, true, gmPod, pkg.PtpContainerName, []string{"curl", pkg.MetricsEndPoint})
-					return checkClockClassInMetrics(buf.String(), "7") || checkClockClassInMetrics(buf.String(), "248")
+					return checkClockClassInMetrics(buf.String(), "7")
 				}, pkg.TimeoutIn5Minutes, 2*time.Second).Should(BeTrue(),
-					"Expected GM clock class to degrade before collecting events")
+					"Expected GM clock class to reach CC7 (holdover) before collecting events")
 
 				events := getGMEvents(subs.GNSS, subs.CLOCKCLASS, subs.LOCKSTATE, 30*time.Second)
 				fmt.Fprintf(GinkgoWriter, "TGMBC GM loss events: %v\n", events)
@@ -3490,12 +3475,12 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				verifyEvent(events[ptpEvent.PtpStateChange], ptpEvent.HOLDOVER)
 				stopMonitor(term)
 
-				By("Verifying BC parent gm.ClockClass cascades to CC7/CC248 via PMC")
+				By("Verifying BC parent gm.ClockClass cascades to CC7 via PMC")
 				Eventually(func() bool {
 					cc, err := ptptesthelper.GetClockClassViaPMC(fullConfig, "/var/run/ptp4l.0.config")
-					return err == nil && (cc == int(fbprotocol.ClockClass7) || cc == ClockClassFreerun)
+					return err == nil && cc == int(fbprotocol.ClockClass7)
 				}, pkg.TimeoutIn10Minutes, 2*time.Second).Should(BeTrue(),
-					"Expected BC parent gm.ClockClass to cascade-degrade after GM holdover event")
+					"Expected BC parent gm.ClockClass to cascade to CC7 after GM holdover event")
 
 				term2, err2 := event.MonitorPodLogsRegex()
 				defer func() { stopMonitor(term2) }()
@@ -4684,20 +4669,19 @@ func ensureGMPtpConfigRestored() {
 	}
 }
 
-// requireDiscoveryAfterRefresh skips when a forced rediscovery lost PtpConfigs or
-// the clock-under-test pod (common when parallel BeforeSuite clean.All races serial).
+// requireDiscoveryAfterRefresh fails when a forced rediscovery lost PtpConfigs or
+// the clock-under-test pod (e.g. wiped mid-run). Soft Skip hid those regressions.
 func requireDiscoveryAfterRefresh(cfg *testconfig.TestConfig, wantMode testconfig.PTPMode) {
-	if cfg.Status != testconfig.DiscoverySuccessStatus {
-		Skip(fmt.Sprintf("PTP discovery failed after refresh (status=%s, mode=%s); "+
+	Expect(cfg.Status).To(Equal(testconfig.DiscoverySuccessStatus),
+		fmt.Sprintf("PTP discovery failed after refresh (status=%s, mode=%s); "+
 			"PtpConfigs may have been wiped by a concurrent suite",
 			cfg.Status, cfg.PtpModeDiscovered))
-	}
-	if cfg.DiscoveredClockUnderTestPod == nil {
-		Skip("DiscoveredClockUnderTestPod is nil after refresh")
-	}
-	if wantMode != testconfig.None && cfg.PtpModeDiscovered != wantMode {
-		Skip(fmt.Sprintf("discovered mode %s != required %s after refresh",
-			cfg.PtpModeDiscovered, wantMode))
+	Expect(cfg.DiscoveredClockUnderTestPod).NotTo(BeNil(),
+		"DiscoveredClockUnderTestPod is nil after refresh")
+	if wantMode != testconfig.None {
+		Expect(cfg.PtpModeDiscovered).To(Equal(wantMode),
+			fmt.Sprintf("discovered mode %s != required %s after refresh",
+				cfg.PtpModeDiscovered, wantMode))
 	}
 }
 
@@ -5000,7 +4984,7 @@ func anyClockClassDifferent(fullConfig testconfig.TestConfig, excludedClass stri
 // GNSS→ts2phc→DPLL→PMC pipeline. Downstream OC/BC profiles that still use the
 // default clock_class_threshold of 7 reject GMs with class > 7, so we must wait
 // before any slave sync assertion. (TGMBC BC configs raise the threshold so
-// cascading holdover can observe CC7/CC248.)
+// cascading holdover can observe CC7.)
 // The function is a no-op when there is no WPC GM in the topology.
 func waitForWPCGMReady(fullConfig testconfig.TestConfig) {
 	if fullConfig.PtpModeDiscovered != testconfig.TelcoGMOC &&

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -3459,12 +3459,22 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				Expect(simErr).ToNot(HaveOccurred())
 				defer func() { _ = ptphelper.GNSSSimSignalRestore() }()
 
-				By("Waiting for GM clock class to degrade in metrics before collecting events")
+				// Assert holdover cascade immediately. A long event-collection wait
+				// after this lets gnss-sim leave HOLDOVER (CC7) for FREERUN (CC248),
+				// so a later CC7-only PMC check would miss the holdover window.
+				By("Waiting for GM clock class to reach CC7 (holdover) in metrics")
 				Eventually(func() bool {
 					buf, _, _ := pods.ExecCommand(client.Client, true, gmPod, pkg.PtpContainerName, []string{"curl", pkg.MetricsEndPoint})
 					return checkClockClassInMetrics(buf.String(), "7")
 				}, pkg.TimeoutIn5Minutes, 2*time.Second).Should(BeTrue(),
 					"Expected GM clock class to reach CC7 (holdover) before collecting events")
+
+				By("Verifying BC parent gm.ClockClass cascades to CC7 via PMC while still in holdover")
+				Eventually(func() bool {
+					cc, err := ptptesthelper.GetClockClassViaPMC(fullConfig, "/var/run/ptp4l.0.config")
+					return err == nil && cc == int(fbprotocol.ClockClass7)
+				}, pkg.TimeoutIn5Minutes, 2*time.Second).Should(BeTrue(),
+					"Expected BC parent gm.ClockClass to cascade to CC7 after GM holdover")
 
 				events := getGMEvents(subs.GNSS, subs.CLOCKCLASS, subs.LOCKSTATE, 30*time.Second)
 				fmt.Fprintf(GinkgoWriter, "TGMBC GM loss events: %v\n", events)
@@ -3474,13 +3484,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				By("Verifying GM PTP state HOLDOVER")
 				verifyEvent(events[ptpEvent.PtpStateChange], ptpEvent.HOLDOVER)
 				stopMonitor(term)
-
-				By("Verifying BC parent gm.ClockClass cascades to CC7 via PMC")
-				Eventually(func() bool {
-					cc, err := ptptesthelper.GetClockClassViaPMC(fullConfig, "/var/run/ptp4l.0.config")
-					return err == nil && cc == int(fbprotocol.ClockClass7)
-				}, pkg.TimeoutIn10Minutes, 2*time.Second).Should(BeTrue(),
-					"Expected BC parent gm.ClockClass to cascade to CC7 after GM holdover event")
 
 				term2, err2 := event.MonitorPodLogsRegex()
 				defer func() { stopMonitor(term2) }()

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -2983,7 +2983,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 				gmPod := getGMPod()
 
-				// phc2sys is omitted in Kind/netdevsim (shared host CLOCK_REALTIME).
+				// phc2sys -r is stripped in Kind/netdevsim (shared host CLOCK_REALTIME).
 				By("checking sim GM required processes status (ts2phc, ptp4l)", func() {
 					processesArr := [...]string{"ts2phc", "ptp4l"}
 					for _, val := range processesArr {

--- a/test/pkg/ptphelper/ha_discovery_test.go
+++ b/test/pkg/ptphelper/ha_discovery_test.go
@@ -27,14 +27,14 @@ func TestConfigIsPhc2SysHa(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "HA without phc2sysOpts (netdevsim omit)",
+			name: "HA without phc2sysOpts is not HA",
 			profile: ptpv1.PtpProfile{
 				Name:        &name,
 				Ptp4lOpts:   &emptyPtp4l,
 				Phc2sysOpts: nil,
 				PtpSettings: map[string]string{"haProfiles": "test-bc-master1,test-bc-master2"},
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "missing haProfiles",
@@ -51,7 +51,7 @@ func TestConfigIsPhc2SysHa(t *testing.T) {
 			profile: ptpv1.PtpProfile{
 				Name:        &name,
 				Ptp4lOpts:   &emptyPtp4l,
-				Phc2sysOpts: nil,
+				Phc2sysOpts: &phc2sysOpts,
 				PtpSettings: map[string]string{"haProfiles": "test-bc-master1"},
 			},
 			want: false,
@@ -61,7 +61,7 @@ func TestConfigIsPhc2SysHa(t *testing.T) {
 			profile: ptpv1.PtpProfile{
 				Name:        &name,
 				Ptp4lOpts:   func() *string { s := "-2"; return &s }(),
-				Phc2sysOpts: nil,
+				Phc2sysOpts: &phc2sysOpts,
 				PtpSettings: map[string]string{"haProfiles": "test-bc-master1,test-bc-master2"},
 			},
 			want: false,

--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -942,15 +942,12 @@ func hasHaProfiles(ptpSettings map[string]string) bool {
 	return ptpSettings != nil && ptpSettings["haProfiles"] != "" && len(strings.Split(ptpSettings["haProfiles"], ",")) > 1
 }
 
-// Checks for DualNIC BC HA.
-// Phc2sysOpts may be nil in netdevsim/Kind when omitPhc2sysInSimulation strips them
-// to avoid a shared-host CLOCK_REALTIME feedback loop; haProfiles + empty ptp4lOpts
-// are still sufficient to identify the HA profile.
+// Checks for DualNIC BC HA
 func ConfigIsPhc2SysHa(config *ptpv1.PtpConfig) bool {
 	logrus.Infof("Checking if config %s is Phc2Sys HA", config.Name)
 	for _, profile := range config.Spec.Profile {
-		if profile.Ptp4lOpts != nil && *profile.Ptp4lOpts == "" && hasHaProfiles(profile.PtpSettings) {
-			logrus.Infof("Config %s is Phc2Sys HA (phc2sysOpts set=%v)", config.Name, profile.Phc2sysOpts != nil)
+		if profile.Phc2sysOpts != nil && profile.Ptp4lOpts != nil && *profile.Ptp4lOpts == "" && hasHaProfiles(profile.PtpSettings) {
+			logrus.Infof("Config %s is Phc2Sys HA", config.Name)
 			return true
 		}
 	}

--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -1347,13 +1347,11 @@ func CreatePtpConfigBC(policyName, nodeName, ifMasterName, ifSlaveName string, p
 	}
 
 	bcConfig := GetPtp4lConfigWithAuth(BasePtp4lConfig) + "\nboundary_clock_jbod 1\ngmCapable 0"
-	// TGMBC cascading-holdover and DualNicBC topologies need the BC to accept
-	// upstream announces when the GM/T-GM clock class is above the default
-	// threshold of 7 ("Master clock quality received is greater than
-	// configured, ignoring master!"). linuxptp rejects values > 248 for this
-	// option.
-	switch GlobalConfig.PtpModeDesired {
-	case TelcoGMBC, DualNICBoundaryClock, DualNICBoundaryClockHA:
+	// TGMBC cascading-holdover needs the BC to accept upstream announces when the
+	// GM clock class is above the default threshold of 7 ("Master clock quality
+	// received is greater than configured, ignoring master!"). DualNicBC/HA keep
+	// the default 7 so freerun-class GMs are not silently accepted.
+	if GlobalConfig.PtpModeDesired == TelcoGMBC {
 		bcConfig = strings.Replace(bcConfig, "clock_class_threshold 7", "clock_class_threshold 248", 1)
 	}
 	bcConfig = AddAuthSettings(AddInterface(bcConfig, ifSlaveName, 0))
@@ -2498,13 +2496,6 @@ func discoverMode(ptpConfigClockUnderTest []*ptpv1.PtpConfig) {
 		case 2:
 			if numPhc2SysHa == 1 {
 				GlobalConfig.PtpModeDiscovered = DualNICBoundaryClockHA
-				GlobalConfig.Status = DiscoverySuccessStatus
-			} else if ptphelper.IsGnssSimConfigured() {
-				// In Kind/netdevsim, omitPhc2sysInSimulation strips Phc2sysOpts from
-				// the primary BC, so both BCs look secondary. Without an HA profile
-				// this is still DualNICBC.
-				logrus.Info("netdevsim/Kind: treating dual secondary BCs without HA as DualNICBC (phc2sys omitted)")
-				GlobalConfig.PtpModeDiscovered = DualNICBoundaryClock
 				GlobalConfig.Status = DiscoverySuccessStatus
 			}
 		}

--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -1066,15 +1066,24 @@ func gnssSerialPort(deviceID string) string {
 	return "/dev/" + deviceID
 }
 
-// omitPhc2sysInSimulation drops phc2sysOpts in netdevsim/Kind CI.
-// Kind nodes share one host CLOCK_REALTIME; phc2sys -r forms a feedback loop
-// with ts2phc/gnss-sim. Baremetal keeps a per-node clock and still runs phc2sys.
-func omitPhc2sysInSimulation(phc2sysOpts *string) *string {
-	if phc2sysOpts != nil && ptphelper.IsGnssSimConfigured() {
-		logrus.Info("Omitting phc2sys in netdevsim/Kind simulation (shared host CLOCK_REALTIME)")
-		return nil
+// stripPhc2sysRealtimeOpts removes -r flags so phc2sys does not drive CLOCK_REALTIME.
+func stripPhc2sysRealtimeOpts(opts string) string {
+	return strings.Join(strings.Fields(strings.ReplaceAll(opts, "-r", "")), " ")
+}
+
+// stripPhc2sysRealtimeInSimulation keeps phc2sysOpts in netdevsim/Kind CI but
+// strips -r. Kind nodes share one host CLOCK_REALTIME; phc2sys -r forms a
+// feedback loop with ts2phc/gnss-sim. Dropping the whole Phc2sysOpts pointer
+// would make every DualNIC BC look secondary (IsSecondaryBc) and break
+// DualNICBC / DualNICBCHA discovery — keep a non-nil opts string instead.
+// Baremetal keeps -r so phc2sys still syncs the per-node system clock.
+func stripPhc2sysRealtimeInSimulation(phc2sysOpts *string) *string {
+	if phc2sysOpts == nil || !ptphelper.IsGnssSimConfigured() {
+		return phc2sysOpts
 	}
-	return phc2sysOpts
+	stripped := stripPhc2sysRealtimeOpts(*phc2sysOpts)
+	logrus.Infof("Stripping phc2sys -r in netdevsim/Kind simulation (shared host CLOCK_REALTIME); opts=%q", stripped)
+	return &stripped
 }
 
 func CreatePtpConfigWPCGrandMaster(policyName string, nodeName string, ifList []string, deviceID string, label string) error {
@@ -1696,10 +1705,10 @@ func createPtpConfigPhc2SysHA(policyName string, nodeName string, haProfiles []s
 	phc2sysOpts := phc2sysDualNicBCHA
 	testParameters, errTestParam := ptptestconfig.GetPtpTestConfig()
 	if errTestParam == nil && testParameters.GlobalConfig.DisableAllSlaveRTUpdate {
-		phc2sysOpts = strings.Join(strings.Fields(strings.ReplaceAll(phc2sysOpts, "-r", "")), " ")
+		phc2sysOpts = stripPhc2sysRealtimeOpts(phc2sysOpts)
 	}
 	ptp4lOpts := "" // no ptp4l options
-	phc2sysOptsPtr := omitPhc2sysInSimulation(&phc2sysOpts)
+	phc2sysOptsPtr := stripPhc2sysRealtimeInSimulation(&phc2sysOpts)
 
 	ptpProfile := ptpv1.PtpProfile{
 		Name:                  &policyName,
@@ -2212,7 +2221,7 @@ func AddAuthSettings(ptpConfig string) string {
 // createTelcoBCConfig creates a multi-profile PTP config for Telco Boundary Clock
 // with separate receiver (tbc-tr) and transmitter (tbc-tt) profiles
 func createTelcoBCConfig(configName string, receiverConfig, transmitterConfig string, ptp4lOpts, phc2sysOpts *string, nodeLabel string, priority *int64, ptpSchedulingPolicy string, ptpSchedulingPriority *int64, ts2phcConfig string, ts2phcOpts *string, plugins map[string]*apiextensions.JSON) error {
-	phc2sysOpts = omitPhc2sysInSimulation(phc2sysOpts)
+	phc2sysOpts = stripPhc2sysRealtimeInSimulation(phc2sysOpts)
 	// Create receiver profile (tbc-tr)
 	receiverProfileName := "tbc-tr"
 	receiverProfile := ptpv1.PtpProfile{
@@ -2271,7 +2280,7 @@ func createTelcoBCConfig(configName string, receiverConfig, transmitterConfig st
 
 func createConfigWithTs2PhcAndPlugins(profileName string, ifaceName, ptp4lOpts *string, ptp4lConfig string, ts2phcConfig string, phc2sysOpts *string, nodeLabel string, priority *int64, ptpSchedulingPolicy string, ptpSchedulingPriority *int64, ts2phcOpts *string, plugins map[string]*apiextensions.JSON) error {
 	thresholds := ptpv1.PtpClockThreshold{}
-	phc2sysOpts = omitPhc2sysInSimulation(phc2sysOpts)
+	phc2sysOpts = stripPhc2sysRealtimeInSimulation(phc2sysOpts)
 
 	testParameters, err := ptptestconfig.GetPtpTestConfig()
 	if err != nil {
@@ -2311,11 +2320,10 @@ func createConfig(profileName string, ifaceName, ptp4lOpts *string, ptp4lConfig 
 	thresholds.HoldOverTimeout = int64(testParameters.GlobalConfig.HoldOverTimeout)
 
 	if testParameters.GlobalConfig.DisableAllSlaveRTUpdate && nodeLabel != pkg.PtpGrandmasterNodeLabel && phc2sysOpts != nil {
-		noRT := strings.ReplaceAll(*phc2sysOpts, "-r", "")
-		noRT = strings.Join(strings.Fields(noRT), " ")
+		noRT := stripPhc2sysRealtimeOpts(*phc2sysOpts)
 		phc2sysOpts = &noRT
 	}
-	phc2sysOpts = omitPhc2sysInSimulation(phc2sysOpts)
+	phc2sysOpts = stripPhc2sysRealtimeInSimulation(phc2sysOpts)
 
 	ptpProfile := ptpv1.PtpProfile{Name: &profileName, Interface: ifaceName, Phc2sysOpts: phc2sysOpts, Ptp4lOpts: ptp4lOpts, PtpSchedulingPolicy: &ptpSchedulingPolicy, PtpSchedulingPriority: ptpSchedulingPriority,
 		PtpClockThreshold: &thresholds}

--- a/test/pkg/testconfig/testconfig_test.go
+++ b/test/pkg/testconfig/testconfig_test.go
@@ -608,3 +608,44 @@ func GeneratePTPObjects(mode PTPMode) {
 		_ = testclient.GetTestClientSet(mockClientObjects)
 	}
 }
+
+func TestStripPhc2sysRealtimeOpts(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "-a -r -n 24 -m -N 8 -R 16", want: "-a -n 24 -m -N 8 -R 16"},
+		{in: "-a -r -r -n 24", want: "-a -n 24"},
+		{in: "-a -n 24", want: "-a -n 24"},
+		{in: "  -a   -r  -m  ", want: "-a -m"},
+	}
+	for _, tt := range tests {
+		if got := stripPhc2sysRealtimeOpts(tt.in); got != tt.want {
+			t.Fatalf("stripPhc2sysRealtimeOpts(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestStripPhc2sysRealtimeInSimulation(t *testing.T) {
+	t.Run("kind strips -r but keeps opts", func(t *testing.T) {
+		t.Setenv("GNSS_SIM_NMEA_DEVICE", "ttyGNSS_TS2PHC")
+		opts := "-a -r -n 24 -m"
+		got := stripPhc2sysRealtimeInSimulation(&opts)
+		if got == nil {
+			t.Fatal("expected non-nil phc2sysOpts so DualNICBC primary stays distinguishable from secondary")
+		}
+		if *got != "-a -n 24 -m" {
+			t.Fatalf("got %q, want %q", *got, "-a -n 24 -m")
+		}
+	})
+	t.Run("baremetal keeps -r", func(t *testing.T) {
+		t.Setenv("GNSS_SIM_NMEA_DEVICE", "ttyGNSS_TS2PHC") // force set then clear
+		_ = os.Unsetenv("GNSS_SIM_NMEA_DEVICE")
+		_ = os.Unsetenv("GNSS_SIM_IFACE1")
+		bare := "-a -r -n 24"
+		gotBare := stripPhc2sysRealtimeInSimulation(&bare)
+		if gotBare == nil || *gotBare != bare {
+			t.Fatalf("without GNSS_SIM env, opts should be unchanged; got %v", gotBare)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Restore Fail/Expect (instead of Skip) for serial slave discovery, parallel discovery/CUT pod, and `requireDiscoveryAfterRefresh`, so mid-run config loss and fabric/discovery bugs surface again.
- Remove Kind DualNICBC invent-on-success, HA detection without `Phc2sysOpts`, DualNicBC/HA `clock_class_threshold` 248, CC7||CC248 soft asserts, webhook/consumer Skips, and loose HA failover `Eventually` checks that can hide never-failover/flapping.
- Keep sim-gated phc2sys / HW GNSS skips (needed for Kind/netdevsim).

## Test plan
- [ ] Unit: `go test ./test/pkg/ptphelper/ ./test/pkg/testconfig/`
- [ ] Confirm DualNICBCHA / DualNicBC Kind jobs fail closed on discovery when phc2sys is omitted (no fake DualNICBC success)
- [ ] Confirm TGMBC holdover asserts require CC7 (not CC7||CC248)
- [ ] Confirm HA failover still passes with hard transition Expects on baremetal DualNICBCHA
- [ ] Confirm netdevsim CI still skips HW GNSS / phc2sys tests when gnss-sim is active